### PR TITLE
Apply Liskov-Substitution-Principle and use a more suitable type for …

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -1476,7 +1476,7 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
      *
      * @param highlighter
      */
-    public void setHighlighter(ChartHighlighter highlighter) {
+    public void setHighlighter(IHighlighter highlighter) {
         mHighlighter = highlighter;
     }
 


### PR DESCRIPTION
…`setHighlighter` method's parameter.

## PR Checklist:
- [X] I have tested this extensively and it does not break any existing behavior.
- [X] I have added/updated examples and tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
I was working with this library for a while and tried to make a custom `IHighligher` for been used along with `PieChart` but I realized that wasn't able to provide the a class that extends from `ChartHighlighter` for `PieChart`'s. 

<!-- What does this add/ remove/ fix/ change? -->
I just modified the signature of `setHighlighter` making it more general and more suitable for been used in this context.

<!-- WHY should this PR be merged into the main library? -->
It fixes a bug in core code and will let other developers to provide custom highlighters without problems.